### PR TITLE
Missed javadoc comment fix in SpeechHelper

### DIFF
--- a/src/main/java/com/example/chermn/SpeechHelper.java
+++ b/src/main/java/com/example/chermn/SpeechHelper.java
@@ -18,6 +18,13 @@ package com.example.chermn;
  */
 public class SpeechHelper {
 
+    /**
+     * Public constructor for the SpeechHelper class.
+     */
+    public SpeechHelper() {
+
+    }
+
     /** The currently running speech process, if any. */
     private static Process currentSpeechProcess;
 


### PR DESCRIPTION
Fixed one last javadoc warning I missed earlier.