### PR TITLE
Set max width for the password fields

### DIFF
--- a/src/main/resources/com/example/chermn/teacher-changePassword.fxml
+++ b/src/main/resources/com/example/chermn/teacher-changePassword.fxml
@@ -56,6 +56,7 @@
 
     <!-- New Password Field -->
     <PasswordField fx:id="newPasswordField"
+                   maxWidth="200"
                    GridPane.columnIndex="1"
                    GridPane.rowIndex="1">
         <GridPane.margin>
@@ -80,6 +81,7 @@
 
     <!-- Re-enter Password Field -->
     <PasswordField fx:id="reconfirmPasswordField"
+                   maxWidth="200"
                    GridPane.columnIndex="1"
                    GridPane.rowIndex="2">
         <GridPane.margin>


### PR DESCRIPTION
Set the max width of the password fields for the teacher and parent home screen, to avoid stretching all the way past the screen.